### PR TITLE
update version to 1.0.7

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "deepl",
 	"name": "DeepL",
-	"version": "1.0.6",
+	"version": "1.0.7",
 	"minAppVersion": "0.15.0",
 	"description": "Allows translation of selected texts into more than 25 languages with DeepL.",
 	"author": "Till Friebe",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "obsidian-deepl",
-	"version": "1.0.6",
+	"version": "1.0.7",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-deepl",
-			"version": "1.0.6",
+			"version": "1.0.7",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^16.11.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-deepl",
-	"version": "1.0.6",
+	"version": "1.0.7",
 	"description": "Allows translation of selected texts into more than 25 languages with DeepL for Obsidian.md.",
 	"main": "main.js",
 	"scripts": {


### PR DESCRIPTION
Hi. The latest release `1.0.7` seems not to have actually been released.

What I mean is that, even though `1.0.7` has already been released, the `manifest.json` is not updated, which causes Obsidian to misunderstand `1.0.6` is the latest release.

Please refer to this for how Obsidian finds the latest version.

https://tfthacker.com/brat-developers#How+Obsidian+loads+plugins

So you need to update `manifest.json`'s `version` to `1.0.7` to make the latest release available.