### PR TITLE
Add new automatic append translation feature and newline toggle

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -96,6 +96,35 @@ export default class DeepLPlugin extends Plugin {
 		});
 
 		this.addCommand({
+            id: "translate-and-append-selection-automatically",
+            name: "Translate selection: Automatically append selection",
+            editorCallback: async (editor: Editor) => {
+                const selection = editor.getSelection();
+                if (selection === "") {
+                    new Notice("No text selected.");
+                    return;
+                }
+
+                try {
+                    const translation = await this.deeplService.translate(
+                        selection,
+                        this.settings.toLanguage,
+                        this.settings.fromLanguage
+                    );
+                    const textToAppend = this.settings.appendNewLine ? '\n' + translation[0].text : translation[0].text;
+                    editor.replaceSelection(selection + textToAppend);
+                } catch (error) {
+                    if (error instanceof DeepLException) {
+                        new Notice(error.message);
+                    } else {
+                        console.error(error, error.stack);
+                        new Notice("An unknown error occurred. See console for details.");
+                    }
+                }
+            }
+        });
+
+		this.addCommand({
 			id: "deepl-translate-selection-to",
 			name: "Translate selection: to language",
 			editorCallback: async (editor: Editor) => {

--- a/src/settings/pluginSettings.ts
+++ b/src/settings/pluginSettings.ts
@@ -5,6 +5,7 @@ export interface DeepLPluginSettings {
 	showStatusBar: boolean;
 	useProAPI: boolean;
 	formality: string;
+	appendNewLine: boolean;
 }
 
 export const formalities: Record<string, string> = {
@@ -20,4 +21,5 @@ export const defaultSettings: Partial<DeepLPluginSettings> = {
 	showStatusBar: true,
 	useProAPI: false,
 	formality: "default",
+	appendNewLine: false,	
 };

--- a/src/settings/settingTab.ts
+++ b/src/settings/settingTab.ts
@@ -49,6 +49,10 @@ export class SettingTab extends PluginSettingTab {
 				"The target language can be selected by suggestion modal. The translation will be appended to the selection."
 			);
 
+        new Setting(containerEl)
+            .setName("Translate selection: Automatically append selection")
+            .setDesc("The translation will be appended to the selection using the 'To language' setting automatically, without the suggestion modal.");
+
 		containerEl.createEl("h4", {
 			text: "Language settings",
 		});
@@ -105,6 +109,18 @@ export class SettingTab extends PluginSettingTab {
 						await this.plugin.saveSettings();
 					})
 			);
+
+        new Setting(containerEl)
+            .setName("When appending text, add a new line before appending the translation?")
+            .setDesc("If enabled, adds a new line before appending the translated text.")
+            .addToggle((toggle) => 
+                toggle
+                    .setValue(this.plugin.settings.appendNewLine)
+                    .onChange(async (value) => {
+                        this.plugin.settings.appendNewLine = value;
+                        await this.plugin.saveSettings();
+                    })
+            );
 
 		containerEl.createEl("h4", {
 			text: "Authentication settings",


### PR DESCRIPTION
Implement a new command 'Translate selection: Automatically append selection' that automatically uses the predefined 'To language' to translate and append the selected text without requiring user interaction through a modal. Enhance both append functionalities with a configurable newline toggle, allowing users to decide if a newline should be added before appending the translated text.

(Sorry for the messy first commit, it was my first time ever doing a pull request! 🙇‍♂️)